### PR TITLE
Display character button as a component instead of checkbox input

### DIFF
--- a/src/components/Preferences.js
+++ b/src/components/Preferences.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Character from "./character/Character";
 
 import "./Preferences.css";
 const Preferences = ({ userPref, setUserPref }) => {
@@ -28,20 +29,20 @@ const Preferences = ({ userPref, setUserPref }) => {
 
       <div className="break"></div>
       <div className="eighty-width parent">
-        {" "}
         {userPref.map((char) => {
           return (
-            <div>
-              <input
-                type="checkbox"
-                id={`custom-checkbox-${char.id}`}
-                name={char.name}
-                value={char.name}
-                checked={char.checked}
-                onChange={() => handleOnChange(char.id, !char.checked)}
-              />
-              <label for={`custom-checkbox-${char.id}`}>{char.name}</label>
-            </div>
+            <Character {...char} handleClick={handleOnChange} />
+            // <div>
+            //   <input
+            //     type="checkbox"
+            //     id={`custom-checkbox-${char.id}`}
+            //     name={char.name}
+            //     value={char.name}
+            //     checked={char.checked}
+            //     onChange={() => handleOnChange(char.id, !char.checked)}
+            //   />
+            //   <label for={`custom-checkbox-${char.id}`}>{char.name}</label>
+            // </div>
           );
         })}
       </div>

--- a/src/components/character/Character.css
+++ b/src/components/character/Character.css
@@ -1,0 +1,13 @@
+.character__container {
+  border: solid 2px lightgreen;
+  background-color: white;
+  color: green;
+  padding: 10px;
+  min-width: 50px;
+  cursor: pointer;
+}
+
+.character__container.checked {
+  background-color: green;
+  color: white;
+}

--- a/src/components/character/Character.js
+++ b/src/components/character/Character.js
@@ -1,0 +1,16 @@
+import React from "react";
+import "./Character.css";
+
+const Character = ({ id, name, checked, handleClick }) => {
+  return (
+    <div
+      className={`character__container ${checked ? "checked" : ""}`}
+      onClick={() => handleClick(id, !checked)}
+    >
+      {checked ? <span>✓ </span> : <span>X </span>}
+      {name}
+    </div>
+  );
+};
+
+export default Character;


### PR DESCRIPTION
TODO:
- styles for `input` can be removed from Preferences.css
- layout for displaying the character buttons can be improved, e.g. add
margin for some spacing in between